### PR TITLE
Stabilise SRO solver with scaled updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
-# ML8501
+# Iterative SRO for MMSE prediction
+
+This repository provides a reference implementation of the iterative
+successive regularized optimisation (SRO) algorithm from
+[Sketching for convex and nonconvex regularized least squares with sharp guarantees](https://openreview.net/pdf?id=7liN6uHAQZ)
+and applies it to MMSE prediction tasks on omics datasets.
+
+The code supports both convex (ridge, lasso) and non-convex (SCAD)
+regularisers and offers different sketching strategies, including
+CountSketch and CountSketch+Gaussian sketches implemented through
+[`pylspack`](https://github.com/IBM/pylspack).
+
+## Environment setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running experiments
+
+The main experiment driver lives in `experiments/run_sro_omics.py`. It can work
+with a CSV omics dataset or generate a synthetic benchmark.
+
+### Synthetic quick start
+
+```bash
+python experiments/run_sro_omics.py --synthetic --iterations 4 --inner-iterations 60 \
+    --sketch-size 64 --count-size 128 --output results.csv
+```
+
+### Real omics data
+
+```bash
+python experiments/run_sro_omics.py --data path/to/omics.csv --target mmse_column \
+    --drop-columns patient_id --iterations 6 --inner-iterations 120 --history-dir histories
+```
+
+Command-line arguments let you control the choice of regulariser,
+sketch sizes, the proximal step scaling (default `0.25` for stable
+sketched updates), stopping tolerance and whether sketches are
+resampled per iteration. The script prints a comparison table across
+baselines (ridge, lasso) and the configured SRO models. Optionally,
+optimisation histories are saved as JSON files.
+
+## Module overview
+
+- `sro/regularizers.py` implements the proximal operators and penalties for
+  L2, L1 and SCAD regularisers.
+- `sro/sketching.py` wraps the sketch primitives, delegating CountSketch
+  and hybrid transforms to `pylspack`.
+- `sro/sro_solver.py` contains the iterative SRO optimizer capable of
+  handling convex and non-convex penalties.
+- `experiments/run_sro_omics.py` orchestrates data loading, model fitting
+  and metric reporting on omics→MMSE tasks.
+
+## Reproducibility
+
+Set the `--random-state` flag to enforce deterministic data splits and
+Gaussian sketch matrices. CountSketch transforms rely on `pylspack`'s
+internal RNG, so runs may differ slightly across executions when sketch
+resampling is enabled.

--- a/experiments/run_sro_omics.py
+++ b/experiments/run_sro_omics.py
@@ -1,0 +1,314 @@
+"""End-to-end experiment runner for Iterative SRO on omics data."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import Lasso, Ridge
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from sro import (
+    IterativeSRO,
+    L1Regularizer,
+    L2Regularizer,
+    SCADRegularizer,
+    SketchConfig,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data", type=Path, help="Path to CSV file containing the dataset.")
+    parser.add_argument(
+        "--target",
+        default="mmse",
+        help="Name of the MMSE target column in the dataset (default: mmse).",
+    )
+    parser.add_argument(
+        "--drop-columns",
+        nargs="*",
+        default=None,
+        help="Optional list of columns to drop before modelling.",
+    )
+    parser.add_argument(
+        "--test-size",
+        type=float,
+        default=0.2,
+        help="Hold-out fraction for the test split (default: 0.2).",
+    )
+    parser.add_argument(
+        "--random-state",
+        type=int,
+        default=13,
+        help="Random seed for reproducibility.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=5,
+        help="Number of outer SRO iterations (default: 5).",
+    )
+    parser.add_argument(
+        "--inner-iterations",
+        type=int,
+        default=100,
+        help="Number of proximal updates per SRO iteration (default: 100).",
+    )
+    parser.add_argument(
+        "--tol",
+        type=float,
+        default=1e-5,
+        help="Stopping tolerance for both inner and outer loops.",
+    )
+    parser.add_argument(
+        "--step-scale",
+        type=float,
+        default=0.25,
+        help="Step size multiplier relative to the Lipschitz constant (default: 0.25).",
+    )
+    parser.add_argument(
+        "--sketch-size",
+        type=int,
+        default=128,
+        help="Number of rows for Gaussian sketches (default: 128).",
+    )
+    parser.add_argument(
+        "--count-size",
+        type=int,
+        default=None,
+        help="Number of rows for count sketches (default: min(2*sketch_size, n_samples)).",
+    )
+    parser.add_argument(
+        "--lasso-strength",
+        type=float,
+        default=0.05,
+        help="Lambda parameter for the L1 regulariser (default: 0.05).",
+    )
+    parser.add_argument(
+        "--ridge-strength",
+        type=float,
+        default=1.0,
+        help="Lambda parameter for the L2 regulariser (default: 1.0).",
+    )
+    parser.add_argument(
+        "--scad-strength",
+        type=float,
+        default=0.05,
+        help="Lambda parameter for the SCAD regulariser (default: 0.05).",
+    )
+    parser.add_argument(
+        "--scad-a",
+        type=float,
+        default=3.7,
+        help="SCAD shape parameter a (default: 3.7).",
+    )
+    parser.add_argument(
+        "--regularizers",
+        nargs="*",
+        default=("lasso", "scad"),
+        choices=("lasso", "ridge", "scad"),
+        help="Regularisers to evaluate with SRO (default: lasso scad).",
+    )
+    parser.add_argument(
+        "--fixed-sketch",
+        action="store_true",
+        help="Reuse the same sketch at every SRO iteration instead of resampling.",
+    )
+    parser.add_argument(
+        "--history-dir",
+        type=Path,
+        default=None,
+        help="Optional directory where per-run optimisation traces are stored as JSON.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to save the metrics table as CSV.",
+    )
+    parser.add_argument(
+        "--synthetic",
+        action="store_true",
+        help="Generate a synthetic omics-like dataset instead of loading from disk.",
+    )
+    parser.add_argument(
+        "--n-samples",
+        type=int,
+        default=500,
+        help="Number of synthetic samples to generate when --synthetic is used.",
+    )
+    parser.add_argument(
+        "--n-features",
+        type=int,
+        default=200,
+        help="Number of synthetic omics features when --synthetic is used.",
+    )
+    return parser.parse_args()
+
+
+def load_dataset(args: argparse.Namespace) -> Tuple[np.ndarray, np.ndarray]:
+    if args.synthetic:
+        X, y = _generate_synthetic(args.n_samples, args.n_features, args.random_state)
+        return X, y
+
+    if args.data is None:
+        raise ValueError("--data must be provided unless --synthetic is set.")
+    frame = pd.read_csv(args.data)
+    if args.drop_columns:
+        frame = frame.drop(columns=list(args.drop_columns), errors="ignore")
+
+    if args.target not in frame.columns:
+        raise ValueError(f"Target column '{args.target}' not found in dataset.")
+
+    frame = frame.select_dtypes(include=[np.number]).dropna(axis=0, how="any")
+    y = frame.pop(args.target).to_numpy(dtype=float)
+    X = frame.to_numpy(dtype=float)
+    return X, y
+
+
+def _generate_synthetic(n_samples: int, n_features: int, seed: int) -> Tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(n_samples, n_features))
+    ground_truth = rng.normal(scale=0.3, size=n_features)
+    y = X @ ground_truth + rng.normal(scale=0.5, size=n_samples)
+    y = np.clip(y, 0, 30)  # mimic MMSE bounds
+    return X, y
+
+
+def build_sro_configs(
+    args: argparse.Namespace, n_train: int
+) -> Iterable[Tuple[str, SketchConfig]]:
+    sketch_size = min(args.sketch_size, n_train)
+    count_size = args.count_size if args.count_size is not None else min(2 * sketch_size, n_train)
+    configs = [
+        ("none", SketchConfig(method="none")),
+    ]
+    if sketch_size >= 1:
+        configs.append(("gaussian", SketchConfig(method="gaussian", sketch_size=sketch_size, random_state=args.random_state)))
+    if count_size >= 1:
+        configs.append(("count", SketchConfig(method="count", sketch_size=count_size, random_state=args.random_state)))
+        if sketch_size >= 1:
+            configs.append(
+                (
+                    "count_gaussian",
+                    SketchConfig(
+                        method="count_gaussian",
+                        sketch_size=sketch_size,
+                        count_size=count_size,
+                        random_state=args.random_state,
+                    ),
+                )
+            )
+    return configs
+
+
+def build_regularizers(args: argparse.Namespace) -> Dict[str, object]:
+    registry = {
+        "lasso": L1Regularizer(args.lasso_strength),
+        "ridge": L2Regularizer(args.ridge_strength),
+        "scad": SCADRegularizer(args.scad_strength, a=args.scad_a),
+    }
+    return {name: registry[name] for name in args.regularizers}
+
+
+def evaluate_models(
+    X_train: np.ndarray,
+    X_test: np.ndarray,
+    y_train: np.ndarray,
+    y_test: np.ndarray,
+    args: argparse.Namespace,
+) -> pd.DataFrame:
+    scaler = StandardScaler()
+    X_train_scaled = scaler.fit_transform(X_train)
+    X_test_scaled = scaler.transform(X_test)
+
+    results: List[Dict[str, object]] = []
+
+    baselines = {
+        "Ridge": Ridge(alpha=args.ridge_strength),
+        "Lasso": Lasso(alpha=args.lasso_strength, max_iter=5000, random_state=args.random_state),
+    }
+
+    for name, model in baselines.items():
+        model.fit(X_train_scaled, y_train)
+        y_pred = model.predict(X_test_scaled)
+        results.append(_make_result_row(name, "baseline", y_test, y_pred))
+
+    regularizers = build_regularizers(args)
+    sketch_configs = list(build_sro_configs(args, X_train.shape[0]))
+
+    for reg_name, regularizer in regularizers.items():
+        for sketch_name, sketch_config in sketch_configs:
+            tag = f"SRO-{reg_name}-{sketch_name}"
+            solver = IterativeSRO(
+                regularizer=regularizer,
+                sketch_config=sketch_config,
+                max_iter=args.iterations,
+                inner_max_iter=args.inner_iterations,
+                tol=args.tol,
+                step_scale=args.step_scale,
+                resample_sketch=not args.fixed_sketch,
+                random_state=args.random_state,
+            )
+            solver.fit(X_train_scaled, y_train)
+            y_pred = solver.predict(X_test_scaled)
+            results.append(_make_result_row(tag, "sro", y_test, y_pred))
+            _maybe_dump_history(args.history_dir, tag, solver)
+
+    return pd.DataFrame(results)
+
+
+def _make_result_row(model_name: str, family: str, y_true: np.ndarray, y_pred: np.ndarray) -> Dict[str, object]:
+    return {
+        "model": model_name,
+        "family": family,
+        "mae": mean_absolute_error(y_true, y_pred),
+        "mse": mean_squared_error(y_true, y_pred),
+        "rmse": np.sqrt(mean_squared_error(y_true, y_pred)),
+        "r2": r2_score(y_true, y_pred),
+    }
+
+
+def _maybe_dump_history(history_dir: Path | None, tag: str, solver: IterativeSRO) -> None:
+    if history_dir is None:
+        return
+    history_dir.mkdir(parents=True, exist_ok=True)
+    path = history_dir / f"{tag}.json"
+    with path.open("w", encoding="utf-8") as file:
+        json.dump(solver.get_history(), file, indent=2)
+
+
+def main() -> None:
+    args = parse_args()
+    X, y = load_dataset(args)
+    print(f"Loaded dataset with {X.shape[0]} samples and {X.shape[1]} features.")
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=args.test_size, random_state=args.random_state
+    )
+
+    results = evaluate_models(X_train, X_test, y_train, y_test, args)
+    results = results.sort_values(by="mse").reset_index(drop=True)
+
+    print("\nModel comparison (sorted by MSE):")
+    print(results.to_string(index=False, float_format=lambda value: f"{value:0.4f}"))
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        results.to_csv(args.output, index=False)
+        print(f"Results saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy>=1.24
+pandas>=2.0
+scipy>=1.10
+scikit-learn>=1.4
+pylspack @ git+https://github.com/IBM/pylspack

--- a/sro/__init__.py
+++ b/sro/__init__.py
@@ -1,0 +1,22 @@
+"""Utilities for iterative SRO experiments."""
+
+from .regularizers import (
+    BaseRegularizer,
+    L1Regularizer,
+    L2Regularizer,
+    NoRegularizer,
+    SCADRegularizer,
+)
+from .sketching import SketchConfig, apply_sketch
+from .sro_solver import IterativeSRO
+
+__all__ = [
+    "BaseRegularizer",
+    "L1Regularizer",
+    "L2Regularizer",
+    "NoRegularizer",
+    "SCADRegularizer",
+    "SketchConfig",
+    "apply_sketch",
+    "IterativeSRO",
+]

--- a/sro/regularizers.py
+++ b/sro/regularizers.py
@@ -1,0 +1,162 @@
+"""Regularizer implementations used by the iterative SRO solver."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+
+
+class BaseRegularizer(Protocol):
+    """Interface for penalties that can be used with :class:`IterativeSRO`."""
+
+    strength: float
+
+    def prox(self, z: np.ndarray, step_size: float) -> np.ndarray:
+        """Return the proximal update ``argmin_x 0.5||x - z||^2 + step_size * h(x)``."""
+
+    def penalty(self, beta: np.ndarray) -> float:
+        """Evaluate ``h(beta)`` for reporting metrics."""
+
+
+@dataclass(frozen=True)
+class NoRegularizer:
+    """No regularisation."""
+
+    strength: float = 0.0
+
+    def prox(self, z: np.ndarray, step_size: float) -> np.ndarray:  # noqa: D401
+        return np.asarray(z, dtype=float)
+
+    def penalty(self, beta: np.ndarray) -> float:  # noqa: D401
+        return 0.0
+
+
+@dataclass(frozen=True)
+class L2Regularizer:
+    """Quadratic (ridge) penalty ``lambda / 2 * ||beta||_2^2``."""
+
+    strength: float
+
+    def prox(self, z: np.ndarray, step_size: float) -> np.ndarray:  # noqa: D401
+        denom = 1.0 + step_size * self.strength
+        return np.asarray(z, dtype=float) / denom
+
+    def penalty(self, beta: np.ndarray) -> float:  # noqa: D401
+        beta = np.asarray(beta, dtype=float)
+        return 0.5 * self.strength * float(beta @ beta)
+
+
+@dataclass(frozen=True)
+class L1Regularizer:
+    """Lasso penalty ``lambda * ||beta||_1``."""
+
+    strength: float
+
+    def prox(self, z: np.ndarray, step_size: float) -> np.ndarray:  # noqa: D401
+        z = np.asarray(z, dtype=float)
+        thresh = self.strength * step_size
+        return np.sign(z) * np.maximum(np.abs(z) - thresh, 0.0)
+
+    def penalty(self, beta: np.ndarray) -> float:  # noqa: D401
+        return self.strength * float(np.linalg.norm(beta, ord=1))
+
+
+@dataclass(frozen=True)
+class SCADRegularizer:
+    """Smoothly clipped absolute deviation (SCAD) penalty."""
+
+    strength: float
+    a: float = 3.7
+
+    def __post_init__(self) -> None:
+        if self.a <= 2.0:
+            msg = "The SCAD parameter 'a' must be greater than 2."
+            raise ValueError(msg)
+
+    def prox(self, z: np.ndarray, step_size: float) -> np.ndarray:  # noqa: D401
+        z = np.asarray(z, dtype=float)
+        out = np.empty_like(z)
+        for idx, value in np.ndenumerate(z):
+            out[idx] = _scad_prox_scalar(float(value), step_size, self.strength, self.a)
+        return out
+
+    def penalty(self, beta: np.ndarray) -> float:  # noqa: D401
+        beta = np.asarray(beta, dtype=float)
+        lam = self.strength
+        a = self.a
+        abs_beta = np.abs(beta)
+        penalties = np.where(
+            abs_beta <= lam,
+            lam * abs_beta,
+            np.where(
+                abs_beta <= a * lam,
+                (-(abs_beta**2) + 2 * a * lam * abs_beta - lam**2) / (2 * (a - 1)),
+                0.5 * (a + 1) * lam**2,
+            ),
+        )
+        return float(np.sum(penalties))
+
+
+def _scad_prox_scalar(z: float, step_size: float, lam: float, a: float) -> float:
+    """Compute the proximal operator of the SCAD penalty for a single value."""
+
+    if lam <= 0:
+        return z
+
+    candidates = set()
+    candidates.add(0.0)
+
+    sign = 1.0 if z >= 0 else -1.0
+    abs_z = abs(z)
+    thresh = lam * step_size
+
+    # Region 1: behaves like soft-thresholding.
+    soft = sign * max(abs_z - thresh, 0.0)
+    if abs(soft) <= lam + 1e-12:
+        candidates.add(soft)
+
+    # Region 2: analytical solution when lambda < |beta| <= a * lambda.
+    denom = (a - 1) - step_size
+    if denom > 1e-12:
+        numerator = (a - 1) * abs_z - step_size * a * lam
+        beta_mag = numerator / denom
+        if lam < beta_mag <= a * lam:
+            candidates.add(sign * beta_mag)
+
+    # Region 3: no shrinkage.
+    if abs_z > a * lam:
+        candidates.add(z)
+
+    # Boundary points ensure we consider potential minima.
+    candidates.add(sign * lam)
+    candidates.add(sign * a * lam)
+
+    def objective(beta: float) -> float:
+        return 0.5 * (beta - z) ** 2 + step_size * _scad_penalty(abs(beta), lam, a)
+
+    best_val = float("inf")
+    best_beta = 0.0
+    for beta in candidates:
+        val = objective(beta)
+        if val < best_val:
+            best_val = val
+            best_beta = beta
+    return best_beta
+
+
+def _scad_penalty(abs_beta: float, lam: float, a: float) -> float:
+    if abs_beta <= lam:
+        return lam * abs_beta
+    if abs_beta <= a * lam:
+        return (-(abs_beta**2) + 2 * a * lam * abs_beta - lam**2) / (2 * (a - 1))
+    return 0.5 * (a + 1) * lam**2
+
+
+__all__ = [
+    "BaseRegularizer",
+    "L1Regularizer",
+    "L2Regularizer",
+    "NoRegularizer",
+    "SCADRegularizer",
+]

--- a/sro/sketching.py
+++ b/sro/sketching.py
@@ -1,0 +1,106 @@
+"""Sketching utilities leveraging :mod:`pylspack`."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+from numpy.random import Generator, default_rng
+from scipy import sparse
+
+try:
+    from pylspack import leverage_scores
+except ImportError as exc:  # pragma: no cover - handled at runtime.
+    raise ImportError(
+        "pylspack must be installed to use sketching utilities."
+    ) from exc
+
+
+@dataclass
+class SketchConfig:
+    """Configuration for generating a sketch matrix."""
+
+    method: str = "none"
+    sketch_size: Optional[int] = None
+    count_size: Optional[int] = None
+    random_state: Optional[int] = None
+
+
+def apply_sketch(
+    X: np.ndarray | sparse.spmatrix,
+    config: SketchConfig,
+    *,
+    reuse_random_state: bool = False,
+) -> np.ndarray:
+    """Apply a sketch to ``X`` according to ``config`` and return ``S @ X``.
+
+    Parameters
+    ----------
+    X:
+        Input matrix with shape ``(n_samples, n_features)``. Dense and sparse
+        inputs are supported and converted to ``float64``.
+    config:
+        Sketch configuration describing which transform to apply.
+    reuse_random_state:
+        When ``True`` the global NumPy RNG is restored after applying the
+        sketch. This is useful when deterministic behaviour is required.
+    """
+
+    method = config.method.lower()
+    if method not in {"none", "gaussian", "count", "count_gaussian"}:
+        msg = f"Unknown sketching method '{config.method}'."
+        raise ValueError(msg)
+
+    if method == "none" or config.sketch_size in {None, 0}:
+        return np.asarray(X, dtype=np.float64)
+
+    X_array = _ensure_c_contiguous(X)
+    n_samples, _ = X_array.shape
+
+    rng: Generator = default_rng(config.random_state)
+    if reuse_random_state and config.random_state is not None:
+        state = np.random.get_state()
+        np.random.seed(config.random_state)
+
+    try:
+        if method == "gaussian":
+            m = int(config.sketch_size)
+            if m <= 0 or m > n_samples:
+                msg = (
+                    "Gaussian sketch size must be in the range ``1..n_samples``."
+                )
+                raise ValueError(msg)
+            projection = rng.normal(size=(m, n_samples)) / np.sqrt(m)
+            return projection @ X_array
+
+        if method == "count":
+            r = int(config.sketch_size)
+            if r <= 0 or r > n_samples:
+                msg = "Count sketch size must satisfy 1 <= r <= n_samples."
+                raise ValueError(msg)
+            X_csr = sparse.csr_matrix(X_array)
+            return leverage_scores.csrcgs(X_csr, m=0, r=r)
+
+        # method == "count_gaussian"
+        m = int(config.sketch_size)
+        r = config.count_size if config.count_size is not None else min(n_samples, 2 * m)
+        if m <= 0 or m > n_samples:
+            msg = "Gaussian rows must satisfy 1 <= m <= n_samples."
+            raise ValueError(msg)
+        if r <= 0 or r > n_samples:
+            msg = "Count sketch rows must satisfy 1 <= r <= n_samples."
+            raise ValueError(msg)
+        X_csr = sparse.csr_matrix(X_array)
+        return leverage_scores.csrcgs(X_csr, m=m, r=r)
+    finally:
+        if reuse_random_state and config.random_state is not None:
+            np.random.set_state(state)
+
+
+def _ensure_c_contiguous(X: np.ndarray | sparse.spmatrix) -> np.ndarray:
+    if sparse.issparse(X):
+        X = X.toarray()
+    return np.ascontiguousarray(X, dtype=np.float64)
+
+
+__all__ = ["SketchConfig", "apply_sketch"]

--- a/sro/sro_solver.py
+++ b/sro/sro_solver.py
@@ -1,0 +1,188 @@
+"""Implementation of the Iterative SRO algorithm."""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Callable, List, Optional
+
+import numpy as np
+from numpy.linalg import norm
+from numpy.random import default_rng
+
+from .regularizers import BaseRegularizer, NoRegularizer
+from .sketching import SketchConfig, apply_sketch
+
+
+@dataclass
+class IterativeSRO:
+    """Iterative SRO solver supporting convex and non-convex penalties."""
+
+    regularizer: BaseRegularizer | None = None
+    sketch_config: SketchConfig | None = None
+    max_iter: int = 10
+    inner_max_iter: int = 100
+    tol: float = 1e-6
+    step_scale: float = 0.25
+    resample_sketch: bool = True
+    random_state: Optional[int] = None
+    sketch_stabiliser: float = 1e-3
+
+    def __post_init__(self) -> None:
+        if self.max_iter <= 0:
+            msg = "max_iter must be positive."
+            raise ValueError(msg)
+        if self.inner_max_iter <= 0:
+            msg = "inner_max_iter must be positive."
+            raise ValueError(msg)
+        if self.tol <= 0:
+            msg = "tol must be positive."
+            raise ValueError(msg)
+        if self.step_scale <= 0:
+            msg = "step_scale must be positive."
+            raise ValueError(msg)
+        if self.sketch_stabiliser < 0:
+            msg = "sketch_stabiliser must be non-negative."
+            raise ValueError(msg)
+        if self.regularizer is None:
+            self.regularizer = NoRegularizer()
+        if self.sketch_config is None:
+            self.sketch_config = SketchConfig(method="none")
+
+        self._rng = default_rng(self.random_state)
+        self.beta_: Optional[np.ndarray] = None
+        self.history_: List[dict[str, float]] = []
+
+    def fit(self, X: np.ndarray, y: np.ndarray) -> IterativeSRO:
+        X = np.asarray(X, dtype=np.float64)
+        y = np.asarray(y, dtype=np.float64).reshape(-1)
+        n_samples, n_features = X.shape
+
+        if n_samples == 0 or n_features == 0:
+            msg = "X must contain at least one sample and one feature."
+            raise ValueError(msg)
+
+        scale = 1.0 / float(n_samples)
+
+        beta = np.zeros(n_features, dtype=np.float64)
+        history: List[dict[str, float]] = []
+
+        for outer_idx in range(self.max_iter):
+            residual = X @ beta - y
+            grad_const = scale * (X.T @ residual)
+
+            sketch_config = self._prepare_sketch_config(outer_idx)
+            sketched = apply_sketch(X, sketch_config, reuse_random_state=True)
+
+            hessian_mv = self._build_hessian_matvec(
+                X,
+                sketched,
+                scale,
+                sketch_config.method,
+            )
+            lipschitz = self._estimate_lipschitz(hessian_mv, n_features)
+            step_size = self.step_scale / max(lipschitz, 1e-12)
+
+            beta_prev = beta.copy()
+            for _ in range(self.inner_max_iter):
+                grad = hessian_mv(beta - beta_prev) + grad_const
+                beta_next = self.regularizer.prox(beta - step_size * grad, step_size)
+                if norm(beta_next - beta) <= self.tol:
+                    beta = beta_next
+                    break
+                beta = beta_next
+
+            beta_change = norm(beta - beta_prev)
+            obj_val = self._objective(X, y, beta)
+            history.append(
+                {
+                    "iteration": outer_idx + 1,
+                    "objective": obj_val,
+                    "beta_change": beta_change,
+                }
+            )
+
+            if beta_change <= self.tol:
+                break
+
+        self.beta_ = beta
+        self.history_ = history
+        return self
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        if self.beta_ is None:
+            msg = "Model has not been fitted yet."
+            raise RuntimeError(msg)
+        X = np.asarray(X, dtype=np.float64)
+        return X @ self.beta_
+
+    def get_history(self) -> List[dict[str, float]]:
+        return list(self.history_)
+
+    def _prepare_sketch_config(self, iteration_index: int) -> SketchConfig:
+        assert self.sketch_config is not None
+        if self.sketch_config.method == "none":
+            return SketchConfig(method="none")
+
+        config = replace(self.sketch_config)
+        if self.resample_sketch:
+            config.random_state = None if self.random_state is None else int(
+                self._rng.integers(0, np.iinfo(np.int32).max)
+            )
+        return config
+
+    def _objective(self, X: np.ndarray, y: np.ndarray, beta: np.ndarray) -> float:
+        n_samples = float(X.shape[0])
+        residual = X @ beta - y
+        loss = 0.5 / n_samples * float(residual @ residual)
+        penalty = self.regularizer.penalty(beta) if self.regularizer else 0.0
+        return loss + penalty
+
+    def _build_hessian_matvec(
+        self,
+        X: np.ndarray,
+        sketched: np.ndarray,
+        scale: float,
+        method: str,
+    ) -> Callable[[np.ndarray], np.ndarray]:
+        stabiliser = 0.0 if method == "none" else float(self.sketch_stabiliser)
+
+        if method == "none":
+
+            def matvec(vec: np.ndarray) -> np.ndarray:
+                return scale * (X.T @ (X @ vec))
+
+            return matvec
+
+        def matvec(vec: np.ndarray) -> np.ndarray:
+            return scale * (sketched.T @ (sketched @ vec)) + stabiliser * vec
+
+        return matvec
+
+    def _estimate_lipschitz(
+        self,
+        matvec: Callable[[np.ndarray], np.ndarray],
+        n_features: int,
+        max_iter: int = 100,
+        tol: float = 1e-4,
+    ) -> float:
+        vec = self._rng.normal(size=n_features)
+        vec_norm = norm(vec)
+        if vec_norm == 0:
+            return 1.0
+        vec /= vec_norm
+
+        eigenvalue = 0.0
+        for _ in range(max_iter):
+            next_vec = matvec(vec)
+            next_norm = norm(next_vec)
+            if next_norm == 0:
+                return max(eigenvalue, 1.0)
+            vec = next_vec / next_norm
+            if abs(next_norm - eigenvalue) <= tol * max(1.0, eigenvalue):
+                eigenvalue = next_norm
+                break
+            eigenvalue = next_norm
+
+        return max(eigenvalue, 1.0)
+
+
+__all__ = ["IterativeSRO"]


### PR DESCRIPTION
## Summary
- rescale the SRO solver to optimise the average squared loss and estimate Hessian Lipschitz constants via matvec power iterations
- add sketch stabilisation and default to a conservative step multiplier so sketched variants remain numerically stable
- document the new step-size default in the README and surface it through the experiment CLI

## Testing
- `python experiments/run_sro_omics.py --synthetic --iterations 5 --inner-iterations 50 --sketch-size 32 --count-size 64 --random-state 0`
- `python experiments/run_sro_omics.py --synthetic --iterations 4 --inner-iterations 60 --sketch-size 64 --count-size 128 --output results.csv`


------
https://chatgpt.com/codex/tasks/task_e_68d37d1c3204832e8e9904cc21250d79