### PR TITLE
Add sketch comparisons and visualizations for SRO experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ successive regularized optimisation (SRO) algorithm from
 and applies it to MMSE prediction tasks on omics datasets.
 
 The code supports both convex (ridge, lasso) and non-convex (SCAD)
-regularisers and offers different sketching strategies, including
-CountSketch and CountSketch+Gaussian sketches implemented through
-[`pylspack`](https://github.com/IBM/pylspack).
+regularisers and offers multiple sketching strategies: Gaussian,
+CountSketch, CountSketch+Gaussian hybrids and SRHT embeddings implemented
+through [`pylspack`](https://github.com/IBM/pylspack).
 
 ## Environment setup
 
@@ -27,7 +27,7 @@ with a CSV omics dataset or generate a synthetic benchmark.
 
 ```bash
 python experiments/run_sro_omics.py --synthetic --iterations 4 --inner-iterations 60 \
-    --sketch-size 64 --count-size 128 --output results.csv
+    --sketch-size 64 --count-size 128 --figure-dir figures --output results.csv
 ```
 
 ### Real omics data
@@ -38,9 +38,13 @@ python experiments/run_sro_omics.py --data path/to/omics.csv --target mmse_colum
 ```
 
 Command-line arguments let you control the choice of regulariser,
-sketch sizes, stopping tolerance and whether sketches are resampled per
-iteration. The script prints a comparison table across baselines (ridge,
-lasso) and the configured SRO models. Optionally, optimisation histories are saved as JSON files.
+sketch sizes (including dedicated CountSketch row counts), stopping
+tolerance and whether sketches are resampled per iteration. The script
+prints a comparison table across baselines (ridge, lasso) and every SRO
+configuration. When `--figure-dir` is provided it also produces grouped
+bar charts for MAE/RMSE/R² across subspaces and convergence plots built
+from the stored optimisation histories. Optionally, optimisation
+histories are saved as JSON files via `--history-dir`.
 
 ## Module overview
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pandas>=2.0
 scipy>=1.10
 scikit-learn>=1.4
 pylspack @ git+https://github.com/IBM/pylspack
+matplotlib>=3.7
+seaborn>=0.13

--- a/sro/__init__.py
+++ b/sro/__init__.py
@@ -7,8 +7,8 @@ from .regularizers import (
     NoRegularizer,
     SCADRegularizer,
 )
-from .sketching_simple import SketchConfig
-from .sro_solver_simple import IterativeSRO
+from .sketching import SketchConfig
+from .sro_solver import IterativeSRO
 
 __all__ = [
     "BaseRegularizer",


### PR DESCRIPTION
## Summary
- expose the full Iterative SRO implementation with Gaussian, CountSketch, hybrid, and SRHT subspace options
- enhance the experiment runner with count-size/figure options, enriched result tables, and automatic visualisations of metrics and convergence
- document the new CLI flags and plotting behaviour and add matplotlib/seaborn dependencies

## Testing
- python -m compileall experiments/run_sro_omics.py sro

------
https://chatgpt.com/codex/tasks/task_e_68d5cd943894832eb73c4cb5744bcb3b